### PR TITLE
remove `library(RDataTracker)` from source

### DIFF
--- a/R/DDGCheckpoint.R
+++ b/R/DDGCheckpoint.R
@@ -27,8 +27,6 @@
 #   <http://www.gnu.org/licenses/>.
 
 
-library(RDataTracker)
-
 # .ddg.checkpoint.file.node creates a checkpoint file node.
 
 .ddg.checkpoint.file.node <- function(fname, dname, checkpoint.name) {


### PR DESCRIPTION
`R CMD check` passes after removing this call

This was causing #60 (i.e. `install_github("dlebauer/RDataTracker@patch-1")` now works